### PR TITLE
Fix obs resource owner

### DIFF
--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -911,10 +911,9 @@ public class GameState {
         for (int i=0; i<vectorObservation[player][0].length; i++) {
             Arrays.fill(vectorObservation[player][0][i], 0);
             Arrays.fill(vectorObservation[player][1][i], 0);
+            Arrays.fill(vectorObservation[player][2][i], 0);
+            Arrays.fill(vectorObservation[player][3][i], 0);
             Arrays.fill(vectorObservation[player][4][i], 0);
-            // temp default value for empty spaces
-            Arrays.fill(vectorObservation[player][2][i], -1);
-            Arrays.fill(vectorObservation[player][3][i], -1);
         }
 
         for (int i = 0; i < pgs.units.size(); i++) {
@@ -922,24 +921,19 @@ public class GameState {
             UnitActionAssignment uaa = unitActions.get(u);
             vectorObservation[player][0][u.getY()][u.getX()] = u.getHitPoints();
             vectorObservation[player][1][u.getY()][u.getX()] = u.getResources();
+            
             final int owner = u.getPlayer();
             if (owner < 0)		// Neutral / resource
-            	vectorObservation[player][2][u.getY()][u.getX()] = -1;
+            	vectorObservation[player][2][u.getY()][u.getX()] = 0;
             else	
-            	vectorObservation[player][2][u.getY()][u.getX()] = (u.getPlayer() + player) % 2;
-            vectorObservation[player][3][u.getY()][u.getX()] = u.getType().ID;
+            	vectorObservation[player][2][u.getY()][u.getX()] = ((u.getPlayer() + player) % 2) + 1;
+            
+            vectorObservation[player][3][u.getY()][u.getX()] = u.getType().ID + 1;
+            
             if (uaa != null) {
                 vectorObservation[player][4][u.getY()][u.getX()] = uaa.action.type;
             } else {
                 vectorObservation[player][4][u.getY()][u.getX()] = UnitAction.TYPE_NONE;
-            }
-        }
-
-        // normalize by getting rid of -1
-       for(int i=0; i<vectorObservation[player][2].length; i++) {
-            for(int j=0; j<vectorObservation[player][2][i].length; j++) {
-                vectorObservation[player][3][i][j] += 1;
-                vectorObservation[player][2][i][j] += 1;
             }
         }
 

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -922,7 +922,11 @@ public class GameState {
             UnitActionAssignment uaa = unitActions.get(u);
             vectorObservation[player][0][u.getY()][u.getX()] = u.getHitPoints();
             vectorObservation[player][1][u.getY()][u.getX()] = u.getResources();
-            vectorObservation[player][2][u.getY()][u.getX()] = (u.getPlayer() + player) % 2;
+            final int owner = u.getPlayer();
+            if (owner < 0)		// Neutral / resource
+            	vectorObservation[player][2][u.getY()][u.getX()] = -1;
+            else	
+            	vectorObservation[player][2][u.getY()][u.getX()] = (u.getPlayer() + player) % 2;
             vectorObservation[player][3][u.getY()][u.getX()] = u.getType().ID;
             if (uaa != null) {
                 vectorObservation[player][4][u.getY()][u.getX()] = uaa.action.type;

--- a/src/rts/GameState.java
+++ b/src/rts/GameState.java
@@ -923,9 +923,7 @@ public class GameState {
             vectorObservation[player][1][u.getY()][u.getX()] = u.getResources();
             
             final int owner = u.getPlayer();
-            if (owner < 0)		// Neutral / resource
-            	vectorObservation[player][2][u.getY()][u.getX()] = 0;
-            else	
+            if (owner >= 0)		// Owned by a player, not neutral
             	vectorObservation[player][2][u.getY()][u.getX()] = ((u.getPlayer() + player) % 2) + 1;
             
             vectorObservation[player][3][u.getY()][u.getX()] = u.getType().ID + 1;


### PR DESCRIPTION
Fixed a bug where state vector observations (used by the python deep learning agents) had incorrect owners for resources when built for the Player 2 perspective.

(also made it slightly faster by just init to 0, and adding +1 where necessary, instead of init to -1, and at the end looping over entire grid and adding +1 everywhere)